### PR TITLE
ping heroku after a time interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,3 +257,8 @@ app.post('/webhook/', function (req, res) {
 app.listen(app.get('port'), function() {
 	console.log('running on port', app.get('port'));
 });
+
+// to keep heroku active
+setInterval(function() {
+  https.get(process.env.HerokuUrl);
+}, 1200000);


### PR DESCRIPTION
Fixes issue #27 i.e. Ping heroku to avoid idling state on heroku, due which the bot exits.