### PR TITLE
Similar U.I. to SUSI web app and increase in the number of results shown

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ app.post('/webhook/', function (req, res) {
 								sendTextMessage(sender, "I found this on the web:", 0);
 								var arr = [];
 								var metaCnt = body.answers[0].metadata.count;
-								for(var i=0;i<((metaCnt>4)?4:metaCnt);i++){
+								for(var i=0;i<((metaCnt>10)?10:metaCnt);i++){
 									arr.push(
 										{
 											"title": body.answers[0].data[i].title,
@@ -153,13 +153,13 @@ app.post('/webhook/', function (req, res) {
 						else{
 							if(body.answers[0].actions[0].type === 'table'){
 								var colNames = body.answers[0].actions[0].columns;
-								if((body.answers[0].metadata.count)>4)
+								if((body.answers[0].metadata.count)>10)
 									sendTextMessage(sender, "Due to message limit, only some results are shown:", 0);
 								else
 									sendTextMessage(sender, "Results are shown below:", 0);
 								var metaCnt = body.answers[0].metadata.count;
 								var arr = [];
-								for(var i=0;i<((metaCnt>4)?4:metaCnt);i++){
+								for(var i=0;i<((metaCnt>10)?10:metaCnt);i++){
 									var titleStr = '';
 									var subtitleStr = '';
 									for(var cN in colNames){

--- a/index.js
+++ b/index.js
@@ -143,8 +143,7 @@ app.post('/webhook/', function (req, res) {
 									"type": "template",
 									"payload": 
 									{
-										"template_type": "list",
-										"top_element_style": "compact",
+										"template_type": "genric",
 										"elements": arr
 									}
 								};
@@ -154,7 +153,7 @@ app.post('/webhook/', function (req, res) {
 						else{
 							if(body.answers[0].actions[0].type === 'table'){
 								var colNames = body.answers[0].actions[0].columns;
-								if((body.answers[0].metadata.count)>5)
+								if((body.answers[0].metadata.count)>4)
 									sendTextMessage(sender, "Due to message limit, only some results are shown:", 0);
 								else
 									sendTextMessage(sender, "Results are shown below:", 0);
@@ -180,8 +179,7 @@ app.post('/webhook/', function (req, res) {
 									"type": "template",
 									"payload": 
 									{
-										"template_type": "list",
-										"top_element_style": "compact",
+										"template_type": "genric",
 										"elements": arr
 									}
 								};


### PR DESCRIPTION
Fixes issue #29 i.e. U.I. should be similar to the web app.

Also making the template used as generic, allowed to increase the number of rss and table type replies from 4 to 10.

Screenshots for the change: 
<img width="161" alt="rolloverui1" src="https://user-images.githubusercontent.com/20307535/28451388-97263d80-6e0a-11e7-85bf-8f16eff104e8.PNG">
<img width="166" alt="rolloveruiweb" src="https://user-images.githubusercontent.com/20307535/28451387-97261c56-6e0a-11e7-837b-54aa528f6078.PNG">

