### PR TITLE
Added fuzzy queries shown at the start

### DIFF
--- a/index.js
+++ b/index.js
@@ -292,7 +292,7 @@ function persistentMenuGenerator(){
 				        {
 				          "type":"postback",
 				          "title":"Latest News",
-	                      "payload":"latest_news"
+	                      "payload":"news"
 				        },{
 				          "type":"web_url",
 				          "title":"Visit Repository",
@@ -390,6 +390,35 @@ app.post('/webhook/', function (req, res) {
 						startMessage = errMessage;
 					}
 	          		sendTextMessage(sender, startMessage, 0);
+
+	          		var messageT = {
+						"type": "template",
+						"payload": 
+						{
+							"template_type": "generic",
+							"elements": [
+											{
+		            							"title": 'You can try the following:',
+		            							"buttons": [
+														        {
+														          "type":"postback",
+														          "title":"What is FOSSASIA?",
+											                      "payload":"What is FOSSASIA?"
+														        },{
+														          "type":"postback",
+														          "title":"Who is Einstein?",
+											                      "payload":"Who is Einstein?"
+														        },{
+														          "type":"postback",
+														          "title":"Borders with INDIA",
+											                      "payload":"Borders with INDIA"
+														        }
+														    ]
+		            						}
+		            		]
+						}
+					};
+					sendTextMessage(sender, messageT, 1);
 				});
         	}
         	else if(event.postback.payload === "start_contributing"){
@@ -489,8 +518,8 @@ app.post('/webhook/', function (req, res) {
 			        });
 				});
         	}
-        	else if(event.postback.payload === 'latest_news'){
-        		requestReply(sender, 'news');
+        	else{
+        		requestReply(sender, event.postback.payload);
         	}
 			continue;
 		}


### PR DESCRIPTION
Fixes issue #47 i.e. Some fuzzy queries shown at the start.

Screenshots for the change:
The user is shown with some sample queries to try when he/she clicks "Start chatting" button. 
<img width="461" alt="fbfuzzy" src="https://user-images.githubusercontent.com/20307535/29181070-69ebf0c2-7e17-11e7-83ba-0232db75ade2.PNG">

The sample query clicked by the user is passed on to the SUSI.AI server and answer is fetched from the server for that query.
<img width="471" alt="fbfuzzyanswer" src="https://user-images.githubusercontent.com/20307535/29181129-a4789eca-7e17-11e7-8fe0-e6e647509f23.PNG">